### PR TITLE
Fix template class/struct line formatting (Issue #68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp/issues/68
-Your prepared branch: issue-68-37bd889a
-Your prepared working directory: /tmp/gh-issue-solver-1757726353525
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp/issues/68
+Your prepared branch: issue-68-37bd889a
+Your prepared working directory: /tmp/gh-issue-solver-1757726353525
+
+Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp.Tests/CSharpToCppTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp.Tests/CSharpToCppTransformerTests.cs
@@ -35,5 +35,50 @@ class Program
             var actualResult = transformer.Transform(helloWorldCode);
             Assert.Equal(expectedResult, actualResult);
         }
+
+        [Fact]
+        public void TemplateLineBreakTest()
+        {
+            const string inputCode = @"
+struct ISetter<TValue>
+{
+    virtual void Set(TValue value) = 0;
+
+    virtual ~ISetter<TValue>() = default;
+};";
+            const string expectedResult = @"
+template <typename ...> struct ISetter;
+template <typename TValue>
+struct ISetter<TValue>
+{
+    virtual void Set(TValue value) = 0;
+
+    virtual ~ISetter<TValue>() = default;
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(inputCode);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void InterfaceTemplateLineBreakTest()
+        {
+            const string inputCode = @"
+interface IFactory<TProduct>
+{
+    TProduct Create();
+};";
+            const string expectedResult = @"
+template <typename ...> class IFactory;
+template <typename TProduct>
+class IFactory<TProduct>
+{
+    public:
+    TProduct Create();
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(inputCode);
+            Assert.Equal(expectedResult, actualResult);
+        }
     }
 }

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
@@ -87,13 +87,13 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             (new Regex(@"((public|protected|private|internal|abstract|static) )*(?<category>interface|class|struct)"), "${category}", 0),
             // class GenericCollectionMethodsBase<TElement> {
             // template <typename TElement> class GenericCollectionMethodsBase {
-            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)(?<type>class|struct) (?<typeName>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> ${type} ${typeName};" + Environment.NewLine + "${indent}template <typename ${typeParameters}> ${type} ${typeName}<${typeParameters}>${typeDefinitionEnding}{", 0),
+            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)(?<type>class|struct) (?<typeName>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> ${type} ${typeName};" + Environment.NewLine + "${indent}template <typename ${typeParameters}>" + Environment.NewLine + "${indent}${type} ${typeName}<${typeParameters}>${typeDefinitionEnding}{", 0),
             // static void TestMultipleCreationsAndDeletions<TElement>(SizedBinaryTreeMethodsBase<TElement> tree, TElement* root)
             // template<typename T> static void TestMultipleCreationsAndDeletions<TElement>(SizedBinaryTreeMethodsBase<TElement> tree, TElement* root)
             (new Regex(@"static ([a-zA-Z0-9]+) ([a-zA-Z0-9]+)<([a-zA-Z0-9]+)>\(([^\)\r\n]+)\)"), "template <typename $3> static $1 $2($4)", 0),
             // interface IFactory<out TProduct> {
             // template <typename...> class IFactory;\ntemplate <typename TProduct> class IFactory<TProduct>
-            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)interface (?<interface>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> class ${interface};" + Environment.NewLine + "${indent}template <typename ${typeParameters}> class ${interface}<${typeParameters}>${typeDefinitionEnding}{" + Environment.NewLine + "    public:", 0),
+            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)interface (?<interface>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> class ${interface};" + Environment.NewLine + "${indent}template <typename ${typeParameters}>" + Environment.NewLine + "${indent}class ${interface}<${typeParameters}>${typeDefinitionEnding}{" + Environment.NewLine + "    public:", 0),
             // template <typename TObject, TProperty, TValue>
             // template <typename TObject, typename TProperty, typename TValue>
             (new Regex(@"(?<before>template <((, )?typename [a-zA-Z0-9]+)+, )(?<typeParameter>[a-zA-Z0-9]+)(?<after>(,|>))"), "${before}typename ${typeParameter}${after}", 10),

--- a/python/cs2cpp/cs2cpp.py
+++ b/python/cs2cpp/cs2cpp.py
@@ -86,13 +86,13 @@ class CSharpToCpp(Translator):
         SubRule(r"((public|protected|private|internal|abstract|static) )*(?P<category>interface|class|struct)", r"\g<category>", max_repeat=0),
         # class GenericCollectionMethodsBase<TElement> {
         # template <typename TElement> class GenericCollectionMethodsBase {
-        SubRule(r"(?P<before>\r?\n)(?P<indent>[ \t]*)(?P<type>class|struct) (?P<typeName>[a-zA-Z0-9]+)<(?P<typeParameters>[a-zA-Z0-9 ,]+)>(?P<typeDefinitionEnding>[^{]+){", r"\g<before>\g<indent>template <typename ...> \g<type> \g<typeName>;\n" + "\g<indent>template <typename \g<typeParameters>> \g<type> \g<typeName><\g<typeParameters>>\g<typeDefinitionEnding>{", max_repeat=0),
+        SubRule(r"(?P<before>\r?\n)(?P<indent>[ \t]*)(?P<type>class|struct) (?P<typeName>[a-zA-Z0-9]+)<(?P<typeParameters>[a-zA-Z0-9 ,]+)>(?P<typeDefinitionEnding>[^{]+){", r"\g<before>\g<indent>template <typename ...> \g<type> \g<typeName>;\n" + "\g<indent>template <typename \g<typeParameters>>\n" + "\g<indent>\g<type> \g<typeName><\g<typeParameters>>\g<typeDefinitionEnding>{", max_repeat=0),
         # static void TestMultipleCreationsAndDeletions<TElement>(SizedBinaryTreeMethodsBase<TElement> tree, TElement* root)
         # template<typename T> static void TestMultipleCreationsAndDeletions<TElement>(SizedBinaryTreeMethodsBase<TElement> tree, TElement* root)
         SubRule(r"static ([a-zA-Z0-9]+) ([a-zA-Z0-9]+)<([a-zA-Z0-9]+)>\(([^\)\r\n]+)\)", r"template <typename \3> static \1 \2(\4)", max_repeat=0),
         # interface IFactory<out TProduct> {
         # template <typename...> class IFactory;\ntemplate <typename TProduct> class IFactory<TProduct>
-        SubRule(r"(?P<before>\r?\n)(?P<indent>[ \t]*)interface (?P<interface>[a-zA-Z0-9]+)<(?P<typeParameters>[a-zA-Z0-9 ,]+)>(?P<typeDefinitionEnding>[^{]+){", r"\g<before>\g<indent>template <typename ...> class \g<interface>;\n" + "\g<indent>template <typename \g<typeParameters>> class \g<interface><\g<typeParameters>>\g<typeDefinitionEnding>{\n" + "    public:", max_repeat=0),
+        SubRule(r"(?P<before>\r?\n)(?P<indent>[ \t]*)interface (?P<interface>[a-zA-Z0-9]+)<(?P<typeParameters>[a-zA-Z0-9 ,]+)>(?P<typeDefinitionEnding>[^{]+){", r"\g<before>\g<indent>template <typename ...> class \g<interface>;\n" + "\g<indent>template <typename \g<typeParameters>>\n" + "\g<indent>class \g<interface><\g<typeParameters>>\g<typeDefinitionEnding>{\n" + "    public:", max_repeat=0),
         # template <typename TObject, TProperty, TValue>
         # template <typename TObject, typename TProperty, typename TValue>
         SubRule(r"(?P<before>template <((, )?typename [a-zA-Z0-9]+)+, )(?P<typeParameter>[a-zA-Z0-9]+)(?P<after>(,|>))", r"\g<before>typename \g<typeParameter>\g<after>", max_repeat=10),


### PR DESCRIPTION
## Summary

- Fixes issue #68 by placing class/struct definitions on the next line after template declarations
- Updates both C# and Python implementations for consistency
- Adds comprehensive test cases to prevent regressions

## Changes

### Before
```cpp
template <typename TValue> struct ISetter<TValue>
{
    virtual void Set(TValue value) = 0;
    virtual ~ISetter<TValue>() = default;
};
```

### After
```cpp
template <typename TValue>
struct ISetter<TValue>
{
    virtual void Set(TValue value) = 0;
    virtual ~ISetter<TValue>() = default;
};
```

## Implementation Details

- Modified regex patterns in both `CSharpToCppTransformer.cs` and `cs2cpp.py`
- Updated transformation rules for both `struct/class` and `interface` declarations
- Added `Environment.NewLine` in C# and `\n` in Python to separate template and class/struct lines
- Maintains existing functionality while improving code formatting

## Test Plan

- [x] Added `TemplateLineBreakTest` for struct template declarations
- [x] Added `InterfaceTemplateLineBreakTest` for interface template declarations  
- [x] Verified existing tests continue to pass
- [x] Tested regex patterns independently to ensure correct behavior

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #68