### PR TITLE
Better support for interfaces (issue #67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp/issues/67
-Your prepared branch: issue-67-0326ea0e
-Your prepared working directory: /tmp/gh-issue-solver-1757727040312
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp/issues/67
+Your prepared branch: issue-67-0326ea0e
+Your prepared working directory: /tmp/gh-issue-solver-1757727040312
+
+Proceed.

--- a/TestTransformer/SimpleTest.cs
+++ b/TestTransformer/SimpleTest.cs
@@ -1,0 +1,34 @@
+using System;
+using Platform.RegularExpressions.Transformer.CSharpToCpp;
+
+class SimpleTest 
+{
+    static void Main(string[] args)
+    {
+        var transformer = new CSharpToCppTransformer();
+        
+        // Test simple interface
+        string simpleInterface = @"interface ISimple
+{
+    void Method();
+}";
+        
+        Console.WriteLine("=== SIMPLE INTERFACE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(simpleInterface);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(simpleInterface));
+        
+        // Test templated interface
+        string templatedInterface = @"interface ITest<T>
+{
+    void Method(T value);
+}";
+        
+        Console.WriteLine("\n=== TEMPLATED INTERFACE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(templatedInterface);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(templatedInterface));
+    }
+}

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp.Tests/CSharpToCppTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp.Tests/CSharpToCppTransformerTests.cs
@@ -35,5 +35,127 @@ class Program
             var actualResult = transformer.Transform(helloWorldCode);
             Assert.Equal(expectedResult, actualResult);
         }
+
+        [Fact]
+        public void PragmaOncePreservationTest()
+        {
+            const string input = @"#pragma once
+using System;
+
+class Test
+{
+    public void Method() { }
+}";
+            const string expectedResult = @"#pragma once
+
+class Test
+{
+    public: void Method() { }
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(input);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void PragmaWarningRemovalTest()
+        {
+            const string input = @"#pragma warning disable CS1591
+using System;
+
+class Test
+{
+    public void Method() { }
+}";
+            const string expectedResult = @"class Test
+{
+    public: void Method() { }
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(input);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void SimpleInterfaceToStructTest()
+        {
+            const string input = @"
+interface ITest
+{
+    void Method();
+}";
+            const string expectedResult = @"
+struct ITest
+{
+    public:
+    virtual void Method() = 0;
+    virtual ~ITest() = default;
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(input);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void TemplatedInterfaceToStructTest()
+        {
+            const string input = @"
+interface ITest<T>
+{
+    void Method(T value);
+}";
+            const string expectedResult = @"
+template <typename ...> struct ITest;
+template <typename T>
+struct ITest<T>
+{
+    public:
+    virtual void Method(T value) = 0;
+    virtual ~ITest() = default;
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(input);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void TemplatedClassSeparationTest()
+        {
+            const string input = @"
+class TestClass<T>
+{
+    public T Value { get; set; }
+}";
+            const string expectedResult = @"
+template <typename ...> class TestClass;
+template <typename T>
+class TestClass<T>
+{
+    public: inline T Value;
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(input);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void TemplatedStructSeparationTest()
+        {
+            const string input = @"
+struct TestStruct<T>
+{
+    public T Value { get; set; }
+}";
+            const string expectedResult = @"
+template <typename ...> struct TestStruct;
+template <typename T>
+struct TestStruct<T>
+{
+    public: inline T Value;
+};";
+            var transformer = new CSharpToCppTransformer();
+            var actualResult = transformer.Transform(input);
+            Assert.Equal(expectedResult, actualResult);
+        }
     }
 }

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
@@ -29,7 +29,7 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             (new Regex(@"(\r?\n)?[ \t]+//+.+"), "", 0),
             // #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
             // 
-            (new Regex(@"^\s*?\#pragma[\sa-zA-Z0-9]+$"), "", 0),
+            (new Regex(@"^\s*?\#pragma(?! once)[\sa-zA-Z0-9]+$"), "", 0),
             // {\n\n\n
             // {
             (new Regex(@"{\s+[\r\n]+"), "{" + Environment.NewLine, 0),
@@ -86,14 +86,14 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             // class
             (new Regex(@"((public|protected|private|internal|abstract|static) )*(?<category>interface|class|struct)"), "${category}", 0),
             // class GenericCollectionMethodsBase<TElement> {
-            // template <typename TElement> class GenericCollectionMethodsBase {
-            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)(?<type>class|struct) (?<typeName>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> ${type} ${typeName};" + Environment.NewLine + "${indent}template <typename ${typeParameters}> ${type} ${typeName}<${typeParameters}>${typeDefinitionEnding}{", 0),
+            // template <typename TElement>\nclass GenericCollectionMethodsBase {
+            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)(?<type>class|struct) (?<typeName>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> ${type} ${typeName};" + Environment.NewLine + "${indent}template <typename ${typeParameters}>" + Environment.NewLine + "${indent}${type} ${typeName}<${typeParameters}>${typeDefinitionEnding}{", 0),
             // static void TestMultipleCreationsAndDeletions<TElement>(SizedBinaryTreeMethodsBase<TElement> tree, TElement* root)
             // template<typename T> static void TestMultipleCreationsAndDeletions<TElement>(SizedBinaryTreeMethodsBase<TElement> tree, TElement* root)
             (new Regex(@"static ([a-zA-Z0-9]+) ([a-zA-Z0-9]+)<([a-zA-Z0-9]+)>\(([^\)\r\n]+)\)"), "template <typename $3> static $1 $2($4)", 0),
             // interface IFactory<out TProduct> {
-            // template <typename...> class IFactory;\ntemplate <typename TProduct> class IFactory<TProduct>
-            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)interface (?<interface>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> class ${interface};" + Environment.NewLine + "${indent}template <typename ${typeParameters}> class ${interface}<${typeParameters}>${typeDefinitionEnding}{" + Environment.NewLine + "    public:", 0),
+            // template <typename...> struct IFactory;\ntemplate <typename TProduct>\nstruct IFactory<TProduct>
+            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)interface (?<interface>[a-zA-Z0-9]+)<(?<typeParameters>[a-zA-Z0-9 ,]+)>(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}template <typename ...> struct ${interface};" + Environment.NewLine + "${indent}template <typename ${typeParameters}>" + Environment.NewLine + "${indent}struct ${interface}<${typeParameters}>${typeDefinitionEnding}{" + Environment.NewLine + "    public:", 0),
             // template <typename TObject, TProperty, TValue>
             // template <typename TObject, typename TProperty, typename TValue>
             (new Regex(@"(?<before>template <((, )?typename [a-zA-Z0-9]+)+, )(?<typeParameter>[a-zA-Z0-9]+)(?<after>(,|>))"), "${before}typename ${typeParameter}${after}", 10),
@@ -279,8 +279,12 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             // class IProperty : public ISetter<TValue, TObject>, public IProvider<TValue, TObject>
             (new Regex(@"(?<before>(interface|struct|class) [a-zA-Z_]\w* : ((public [a-zA-Z_][\w:]*(<[a-zA-Z0-9 ,]+>)?, )+)?)(?<inheritedType>(?!public)[a-zA-Z_][\w:]*(<[a-zA-Z0-9 ,]+>)?)(?<after>(, [a-zA-Z_][\w:]*(?!>)|[ \r\n]+))"), "${before}public ${inheritedType}${after}", 10),
             // interface IDisposable {
-            // class IDisposable { public:
-            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)interface (?<interface>[a-zA-Z_]\w*)(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}class ${interface}${typeDefinitionEnding}{" + Environment.NewLine + "    public:", 0),
+            // struct IDisposable { public:
+            (new Regex(@"(?<before>\r?\n)(?<indent>[ \t]*)interface (?<interface>[a-zA-Z_]\w*)(?<typeDefinitionEnding>[^{]+){"), "${before}${indent}struct ${interface}${typeDefinitionEnding}{" + Environment.NewLine + "    public:", 0),
+            // Add virtual destructors for structs (originally interfaces) that contain virtual methods
+            // struct ITest<T> { public: virtual void Method(T value) = 0; }
+            // struct ITest<T> { public: virtual void Method(T value) = 0; virtual ~ITest() = default; }
+            (new Regex(@"(?<beforeEnd>struct (?<structName>[a-zA-Z_][a-zA-Z0-9_]*)[^{]*\{[^}]*public:[^}]*virtual[^}]*?(?=\r?\n[ \t]*}))(?<endIndent>\r?\n[ \t]*)(?<end>})"), "${beforeEnd}${endIndent}    virtual ~${structName}() = default;${endIndent}${end}", 0),
             // struct TreeElement { }
             // struct TreeElement { };
             (new Regex(@"(struct|class) ([a-zA-Z0-9]+)(\s+){([\sa-zA-Z0-9;:_]+?)}([^;])"), "$1 $2$3{$4};$5", 0),
@@ -752,6 +756,11 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             // \n\n}
             // \n}
             (new Regex(@"\r?\n[ \t]*\r?\n(?<end>[ \t]*})"), Environment.NewLine + "${end}", 10),
+            // Fix virtual destructors to use = default instead of = 0 (FINAL STAGE)
+            // Only applies to destructors that were already added (i.e. interfaces converted to structs)
+            // virtual ~ITest() = 0;
+            // virtual ~ITest() = default;
+            (new Regex(@"(\s*)virtual ~([a-zA-Z_][a-zA-Z0-9_]*)\(\) = 0;"), "$1virtual ~$2() = default;", 0),
         }.Cast<ISubstitutionRule>().ToList();
 
         /// <summary>

--- a/examples/TestTransformer/Program.cs
+++ b/examples/TestTransformer/Program.cs
@@ -1,0 +1,65 @@
+using System;
+using Platform.RegularExpressions.Transformer.CSharpToCpp;
+
+class TestTransformer 
+{
+    static void Main(string[] args)
+    {
+        var transformer = new CSharpToCppTransformer();
+        
+        // Test pragma once
+        string pragmaTest = @"#pragma once
+using System;
+
+class Test
+{
+    public void Method() { }
+}";
+        
+        Console.WriteLine("=== PRAGMA ONCE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(pragmaTest);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(pragmaTest));
+        
+        // Test simple interface
+        string simpleInterface = @"
+interface ITest
+{
+    void Method();
+}";
+        
+        Console.WriteLine("\n=== SIMPLE INTERFACE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(simpleInterface);
+        Console.WriteLine("\nOutput:");
+        var simpleOutput = transformer.Transform(simpleInterface);
+        Console.WriteLine(simpleOutput);
+        
+        // Test templated interface
+        string interfaceTest = @"
+interface ITest<T>
+{
+    void Method(T value);
+}";
+        
+        Console.WriteLine("\n=== TEMPLATED INTERFACE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(interfaceTest);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(interfaceTest));
+        
+        // Test struct
+        string structTest = @"struct TestStruct<T>
+{
+    public T Value { get; set; }
+    public void Method() { }
+}";
+        
+        Console.WriteLine("\n=== STRUCT TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(structTest);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(structTest));
+    }
+}

--- a/examples/TestTransformer/TestTransformer.csproj
+++ b/examples/TestTransformer/TestTransformer.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/Platform.RegularExpressions.Transformer.CSharpToCpp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/current_behavior.txt
+++ b/examples/current_behavior.txt
@@ -1,0 +1,43 @@
+=== PRAGMA ONCE TEST ===
+Input:
+#pragma once
+using System;
+
+class Test
+{
+    public void Method() { }
+}
+
+Output:
+class Test
+{
+    public: void Method() { }
+};
+
+=== INTERFACE TEST ===
+Input:
+interface ITest<T>
+{
+    void Method(T value);
+}
+
+Output:
+interface ITest<T>
+{
+    virtual void Method(T value) = 0;
+}
+
+=== STRUCT TEST ===
+Input:
+struct TestStruct<T>
+{
+    public T Value { get; set; }
+    public void Method() { }
+}
+
+Output:
+struct TestStruct<T>
+{
+    public: inline T Value;
+    public: void Method() { }
+};

--- a/examples/debug_destructor.cs
+++ b/examples/debug_destructor.cs
@@ -1,0 +1,4 @@
+interface ITest
+{
+    void Method();
+}

--- a/examples/test_current_transformer.cs
+++ b/examples/test_current_transformer.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using Platform.RegularExpressions.Transformer.CSharpToCpp;
+
+class TestTransformer 
+{
+    static void Main(string[] args)
+    {
+        var transformer = new CSharpToCppTransformer();
+        
+        // Test pragma once
+        string pragmaTest = @"#pragma once
+using System;
+
+class Test
+{
+    public void Method() { }
+}";
+        
+        Console.WriteLine("=== PRAGMA ONCE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(pragmaTest);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(pragmaTest));
+        
+        // Test interface
+        string interfaceTest = @"interface ITest<T>
+{
+    void Method(T value);
+}";
+        
+        Console.WriteLine("\n=== INTERFACE TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(interfaceTest);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(interfaceTest));
+        
+        // Test struct
+        string structTest = @"struct TestStruct<T>
+{
+    public T Value { get; set; }
+    public void Method() { }
+}";
+        
+        Console.WriteLine("\n=== STRUCT TEST ===");
+        Console.WriteLine("Input:");
+        Console.WriteLine(structTest);
+        Console.WriteLine("\nOutput:");
+        Console.WriteLine(transformer.Transform(structTest));
+    }
+}

--- a/examples/test_interface.cs
+++ b/examples/test_interface.cs
@@ -1,0 +1,9 @@
+interface ITest<T>
+{
+    void Method(T value);
+}
+
+class Implementation<T> : ITest<T>
+{
+    public void Method(T value) { }
+}

--- a/examples/test_pragma_once.cs
+++ b/examples/test_pragma_once.cs
@@ -1,0 +1,7 @@
+#pragma once
+using System;
+
+class Test
+{
+    public void Method() { }
+}

--- a/examples/test_struct.cs
+++ b/examples/test_struct.cs
@@ -1,0 +1,5 @@
+struct TestStruct<T>
+{
+    public T Value { get; set; }
+    public void Method() { }
+}


### PR DESCRIPTION
## Summary

This PR implements the four key improvements requested in issue #67:

✅ **#pragma once support**: `#pragma once` directives are now preserved while other pragma directives (like `#pragma warning disable`) are removed

✅ **struct instead of class with public: support**: Interfaces are now converted to structs instead of classes, providing better C++ semantics

✅ **Virtual destructors**: Virtual destructors with `= default` are automatically added to interface-derived structs to ensure proper cleanup

✅ **Better template type arguments placement**: Template declarations and class/struct definitions are now placed on separate lines for better readability (addresses issue #68)

## Technical Implementation

### 1. #pragma once Support
- Modified the pragma removal regex to use negative lookahead: `#pragma(?! once)` 
- This preserves `#pragma once` while removing other pragma directives

### 2. Interface to Struct Conversion  
- Updated both simple and templated interface handling rules
- Simple interfaces: `interface ITest` → `struct ITest`
- Templated interfaces: `interface ITest<T>` → `template <typename T>\nstruct ITest<T>`

### 3. Virtual Destructors
- Added selective virtual destructor insertion for interface-derived structs
- Only applies to structs containing virtual methods (originally interfaces)
- Uses two-stage rule processing to ensure proper `= default` instead of `= 0`

### 4. Template Type Arguments Placement
- Separated template declarations from class/struct definitions
- `template <typename T> class Foo` → `template <typename T>\nclass Foo`

## Test Coverage

Added comprehensive test cases covering:
- `#pragma once` preservation vs `#pragma warning` removal
- Simple interface to struct conversion with virtual destructors
- Templated interface to struct conversion with proper template placement
- Regular struct handling (no unwanted virtual destructors)
- Templated class and struct separation

All existing tests continue to pass, ensuring backward compatibility.

## Example Transformations

**Before:**
```csharp
#pragma once
interface ITest<T>
{
    void Method(T value);
}
```

**After:**
```cpp
#pragma once
template <typename ...> struct ITest;
template <typename T>
struct ITest<T>
{
    public:
    virtual void Method(T value) = 0;
    virtual ~ITest() = default;
};
```

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #67