### PR TITLE
Fix: Convert readonly to const in C++ transformations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp/issues/56
-Your prepared branch: issue-56-0f206a16
-Your prepared working directory: /tmp/gh-issue-solver-1757770374356
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp/issues/56
+Your prepared branch: issue-56-0f206a16
+Your prepared working directory: /tmp/gh-issue-solver-1757770374356
+
+Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
@@ -124,7 +124,7 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             (new Regex(@"(?<access>(private|protected|public): )?static readonly (?<type>[a-zA-Z0-9]+(<[a-zA-Z0-9]+>)?) (?<name>[a-zA-Z0-9_]+) = new \k<type>\((?<arguments>[^\n]+)\);"), "${access}inline static ${type} ${name} = ${type}(${arguments});", 0),
             // public: static readonly string ExceptionContentsSeparator = "---";
             // public: inline static std::string ExceptionContentsSeparator = "---";
-            (new Regex(@"(?<access>(private|protected|public): )?(const|static readonly) string (?<name>[a-zA-Z0-9_]+) = ""(?<string>(\\""|[^""\r\n])+)"";"), "${access}inline static std::string ${name} = \"${string}\";", 0),
+            (new Regex(@"(?<access>(private|protected|public): )?(const|static readonly) string (?<name>[a-zA-Z0-9_]+) = ""(?<string>(\\""|[^""\r\n])+)"";"), "${access}inline static const std::string ${name} = \"${string}\";", 0),
             // private: const int MaxPath = 92;
             // private: inline static const int MaxPath = 92;
             (new Regex(@"(?<access>(private|protected|public): )?(const|static readonly) (?<type>[a-zA-Z0-9]+) (?<name>[_a-zA-Z0-9]+) = (?<value>[^;\r\n]+);"), "${access}inline static const ${type} ${name} = ${value};", 0),

--- a/experiments/Program.cs
+++ b/experiments/Program.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using Platform.RegularExpressions.Transformer.CSharpToCpp;
+
+class Program
+{
+    static void Main()
+    {
+        string inputCode = @"// Test cases for readonly transformations
+public class TestClass
+{
+    // Test string readonly
+    public static readonly string ExceptionContentsSeparator = ""---"";
+    private static readonly string PrivateMessage = ""error"";
+    
+    // Test other types readonly
+    public static readonly int MaxPath = 92;
+    private static readonly bool IsEnabled = true;
+    
+    // Test const (should already work)
+    private const int ConstValue = 42;
+    public const string ConstString = ""test"";
+}";
+        
+        Console.WriteLine("Original code:");
+        Console.WriteLine(inputCode);
+        Console.WriteLine("\n" + new string('=', 50) + "\n");
+        
+        var transformer = new CSharpToCppTransformer();
+        string transformed = transformer.Transform(inputCode);
+        Console.WriteLine("Transformed code:");
+        Console.WriteLine(transformed);
+    }
+}

--- a/experiments/TestTransformations.csproj
+++ b/experiments/TestTransformations.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/Platform.RegularExpressions.Transformer.CSharpToCpp.csproj" />
+  </ItemGroup>
+</Project>

--- a/experiments/readonly_test.cs
+++ b/experiments/readonly_test.cs
@@ -1,0 +1,15 @@
+// Test cases for readonly transformations
+public class TestClass
+{
+    // Test string readonly
+    public static readonly string ExceptionContentsSeparator = "---";
+    private static readonly string PrivateMessage = "error";
+    
+    // Test other types readonly
+    public static readonly int MaxPath = 92;
+    private static readonly bool IsEnabled = true;
+    
+    // Test const (should already work)
+    private const int ConstValue = 42;
+    public const string ConstString = "test";
+}


### PR DESCRIPTION
## Summary

This PR fixes the transformation of C# `readonly` fields to properly use `const` in C++ output, addressing issue #56.

### Changes Made

- Updated the regex pattern on line 127 in `CSharpToCppTransformer.cs` to include `const` in the replacement string for string types
- The pattern `(const|static readonly) string` now correctly outputs `inline static const std::string` instead of `inline static std::string`
- Line 130 already handled non-string types correctly with `const` output

### Before
```cpp
public: inline static std::string ExceptionContentsSeparator = "---";
```

### After  
```cpp
public: inline static const std::string ExceptionContentsSeparator = "---";
```

### Testing

- All existing unit tests pass
- Added test cases in `experiments/` folder to verify the transformation works correctly
- Verified that both `readonly` and `const` C# keywords are now properly converted to `const` in C++

## Test Plan

- [x] Run existing unit tests (`dotnet test`)
- [x] Create and run transformation tests with various readonly field types
- [x] Verify string types now output with `const`
- [x] Verify non-string types continue to work correctly
- [x] Confirm no regressions in existing transformations

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #56