### PR TITLE
Update "hello world" translation test to comply with C++ standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-13-de7b8bf2
+Your prepared working directory: /tmp/gh-issue-solver-1761798275841
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-13-de7b8bf2
-Your prepared working directory: /tmp/gh-issue-solver-1761798275841
-
-Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp.Tests/CSharpToCppTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp.Tests/CSharpToCppTransformerTests.cs
@@ -26,11 +26,26 @@ class Program
 }";
             const string expectedResult = @"class Program
 {
-    public: static void Main(std::string args[])
+    public:
+    void Main(std::vector<std::string> args)
     {
         printf(""Hello, world!\n"");
     }
-};";
+};
+
+int main(int argc, char* argv[])
+{
+    Program program{};
+    try
+    {
+        program.Main(std::vector<std::string>(argv + 1, argv + argc));
+    }
+    catch(...)
+    {
+        // Handle exception
+    }
+    return 0;
+}";
             var transformer = new CSharpToCppTransformer();
             var actualResult = transformer.Transform(helloWorldCode);
             Assert.Equal(expectedResult, actualResult);

--- a/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.CSharpToCpp/CSharpToCppTransformer.cs
@@ -634,6 +634,9 @@ namespace Platform.RegularExpressions.Transformer.CSharpToCpp
             // AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
             // /* No translation. It is not possible to unsubscribe from std::atexit. */
             (new Regex(@"AppDomain\.CurrentDomain\.ProcessExit -= ([a-zA-Z_][a-zA-Z0-9_]*);"), "/* No translation. It is not possible to unsubscribe from std::atexit. */", 0),
+            // class Program { ... public: static void Main(std::string args[]) ... };
+            // class Program { ... public: void Main(std::vector<std::string> args) ... }; \n\nint main(int argc, char* argv[]) { ... }
+            (new Regex(@"(?<before>class Program\s*\{(?:(?!\}\;).|\n)*?)public:\s*static\s+void\s+Main\(std::string\s+args\[\]\)(?<after>(?:(?!\}\;).|\n)*\}\;)"), "${before}public:" + Environment.NewLine + "    void Main(std::vector<std::string> args)${after}" + Environment.NewLine + Environment.NewLine + "int main(int argc, char* argv[])" + Environment.NewLine + "{" + Environment.NewLine + "    Program program{};" + Environment.NewLine + "    try" + Environment.NewLine + "    {" + Environment.NewLine + "        program.Main(std::vector<std::string>(argv + 1, argv + argc));" + Environment.NewLine + "    }" + Environment.NewLine + "    catch(...)" + Environment.NewLine + "    {" + Environment.NewLine + "        // Handle exception" + Environment.NewLine + "    }" + Environment.NewLine + "    return 0;" + Environment.NewLine + "}", 0),
         }.Cast<ISubstitutionRule>().ToList();
 
         /// <summary>


### PR DESCRIPTION
## 📋 Summary

This PR implements modern C++ standards compliance for the C# to C++ transformation, specifically addressing how the `Program` class with `Main` method is translated.

### Changes Made

1. **Transform Main Method Signature**
   - Changed from: `public: static void Main(std::string args[])`
   - Changed to: `public: void Main(std::vector<std::string> args)`
   - Removed `static` modifier to use instance method (modern C++ RAII pattern)
   - Changed parameter type from C-style array to `std::vector` for better C++ idiom

2. **Added C++ Entry Point Wrapper**
   - Generated proper `int main(int argc, char* argv[])` function
   - Instantiates `Program` class using RAII (`Program program{};`)
   - Converts command-line arguments to `std::vector<std::string>`
   - Wrapped `Main()` call in try-catch block for exception handling
   - Returns 0 on success

3. **Updated Test Expectations**
   - Modified `HelloWorldTest` to expect the new output format with both the class and main() wrapper

### Example Transformation

**Input (C#):**
```csharp
using System;
class Program
{
    public static void Main(string[] args)
    {
        Console.WriteLine("Hello, world!");
    }
}
```

**Output (C++):**
```cpp
class Program
{
    public:
    void Main(std::vector<std::string> args)
    {
        printf("Hello, world!\n");
    }
};

int main(int argc, char* argv[])
{
    Program program{};
    try
    {
        program.Main(std::vector<std::string>(argv + 1, argv + argc));
    }
    catch(...)
    {
        // Handle exception
    }
    return 0;
}
```

### Implementation Details

Added a new transformation rule in `FirstStage` that:
- Uses negative lookahead regex to properly handle nested braces in the Program class
- Transforms the static Main method to an instance method
- Appends the C++ main() wrapper after the class definition
- Follows modern C++ practices as discussed in [this article](https://habr.com/en/company/intel/blog/156863/)

### Testing

✅ All tests pass locally
- `EmptyLineTest`: ✓ Passed
- `HelloWorldTest`: ✓ Passed (updated to new format)

---

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)